### PR TITLE
innerHTML führt zu XSS, geändert zu innerText

### DIFF
--- a/cd.html
+++ b/cd.html
@@ -64,19 +64,19 @@ var x = setInterval(function() {
   var seconds = Math.floor( (distance/1000) % 60 );
 
   if(title){
-    document.getElementById("title").innerHTML = title;
+    document.getElementById("title").innerText = title;
     document.getElementById("title").style.marginTop = "-11%";
   }
 
-  document.getElementById("countdown").innerHTML = days + " Tage " + hours + " Stunden "
+  document.getElementById("countdown").innerText = days + " Tage " + hours + " Stunden "
   + minutes + " Minuten " + seconds + " Sekunden ";
     
   if(isNaN(distance)){
-    document.getElementById("countdown").innerHTML = "nope";
+    document.getElementById("countdown").innerText = "nope";
   }
   if (distance < 0) {
     clearInterval(x);
-    document.getElementById("countdown").innerHTML = "EXPIRED";
+    document.getElementById("countdown").innerText = "EXPIRED";
   }
 }, 1000);
 </script>


### PR DESCRIPTION
Hey,

innerHTML mit User Input führt zu einer XSS.

Beispiel: http://localhost:8000/cd.html?date=20201212&title=%22%27%3E%3Cimg%20src=x.png%20onerror=%22alert(%27XSS%27)%22/%3E

Da kein HTML benutzt wird, kann es durch innerText ersetzt werden, was wirklich nur TextNodes hinzufügt und kein HTML interpretiert.